### PR TITLE
added DNDEBUG flag to custom op build flags

### DIFF
--- a/tf_trusted_custom_op/BUILD
+++ b/tf_trusted_custom_op/BUILD
@@ -28,5 +28,5 @@ cc_binary(
         "@com_github_grpc_grpc//:grpc++_reflection",
         ":cpp_model_proto"
     ],
-    copts = ["-pthread", "-std=c++11", "-D_GLIBCXX_USE_CXX11_ABI=0"]
+    copts = ["-pthread", "-std=c++11", "-D_GLIBCXX_USE_CXX11_ABI=0", "-DNDEBUG"]
 )


### PR DESCRIPTION
Without the `DNDEBUG` flag when building the custom op, tensorflow can sporadically throw the following error:

`fastbuild/genfiles/external/local_config_tf/include/tensorflow/core/lib/core/refcount.h:90] Check failed: ref_.load() == 0 (1 vs. 0)
`

as referenced by [https://github.com/tensorflow/tensorflow/issues/17316](https://github.com/tensorflow/tensorflow/issues/17316)

This closes issue [https://github.com/capeprivacy/tf-trusted/issues/26](https://github.com/capeprivacy/tf-trusted/issues/26)